### PR TITLE
build: cross plat build for local usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,17 @@ dist:
 
 .PHONY: build
 build: dist mod
-	CGO_ENABLED=0 go build -o dist/chinmina-bridge .
-	CGO_ENABLED=0 go build -o dist/oidc cmd/create/main.go
+	# build for container use: in future we will need to either use "ko" or
+	# "goreleaser" (or both) to create executables and images in the required
+	# architectures.
+	CGO_ENABLED=0 GOOS=linux go build -o dist/chinmina-bridge .
+	# build for local use, whatever the local platform is
+	CGO_ENABLED=0 go build -o dist/chinmina-bridge-local .
+	CGO_ENABLED=0 go build -o dist/oidc-local cmd/create/main.go
 
 .PHONY: run
 run: build
-	dist/chinmina-bridge
+	dist/chinmina-bridge-local
 
 .PHONY: docker
 docker: build

--- a/integration/docker-compose.yaml
+++ b/integration/docker-compose.yaml
@@ -1,12 +1,16 @@
 services:
   buildkite-agent:
     image: buildkite/agent:3
+    depends_on:
+      - chinmina-bridge
     command: [ "start" ]
     environment:
       - BUILDKITE_AGENT_TOKEN
     volumes:
       - "../agent/startup:/docker-entrypoint.d:ro"
       - "../agent/hooks:/buildkite/hooks:ro"
+    secrets:
+      - netskope
 
   chinmina-bridge:
     image: alpine
@@ -36,3 +40,7 @@ services:
       - "16687:16687" # admin
     environment:
       - LOG_LEVEL=debug
+
+secrets:
+  netskope:
+    environment: "NETSKOPE_CERT"


### PR DESCRIPTION
Updates the build process to allow a local version to be built alongside a Linux version that will be mounted into a container.